### PR TITLE
Catch exception on query exception

### DIFF
--- a/lib/em_mysql2_connection_pool.rb
+++ b/lib/em_mysql2_connection_pool.rb
@@ -19,6 +19,8 @@ class EmMysql2ConnectionPool
       q.callback{ |result| succeed result, connection.affected_rows, &block }
       q.errback{  |error|  fail error, &block }
       return q
+    rescue StandardError => error
+      fail error, &block
     end
     
     def succeed(result, affected_rows, &block)

--- a/lib/em_mysql2_connection_pool/version.rb
+++ b/lib/em_mysql2_connection_pool/version.rb
@@ -1,3 +1,3 @@
-module EmMysql2ConnectionPool
+class EmMysql2ConnectionPool
   VERSION = '0.0.4'
 end


### PR DESCRIPTION
This makes sure exceptions that are thrown from the Mysql2 query method are properly caught and returned as failures.
